### PR TITLE
Only close pane if it is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/doc_view.js
+++ b/src/doc_view.js
@@ -66,7 +66,10 @@ class DocView extends ScrollView {
   }
 
   destroy() {
-    this.pane_.destroy();
+    this.pane_.destroyItem(this);
+    if (this.pane_.getItems().length === 0) {
+      this.pane_.destroy();
+    }
   }
 
   attached() {


### PR DESCRIPTION
This PR fixes https://github.com/sharvil/api-docs/issues/12 in that it only closes the pane if it’s empty after closing the api doc.